### PR TITLE
[30] Added requirements to use this repo as a bazel remote repo

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+    name = "atomspacenode",
+    srcs = [],
+    deps = ["src/atom_space_node:atom_space_node_lib"],
+    visibility = ["//visibility:public"],
+)
+

--- a/commons
+++ b/commons
@@ -1,0 +1,1 @@
+src/commons/


### PR DESCRIPTION
Resolves #30 

* Added a BUILD file in the repo root as required by Bazel
* (hack) Added a symlink to an inner package to make external build work properly. We're already working on this to remove this hack.